### PR TITLE
Set default port to 8080

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  port: process.env.PORT || 8087,
+  port: process.env.PORT || 8080,
   db: {
     database: process.env.DATABASE_NAME || 'asl',
     host: process.env.DATABASE_HOST || 'localhost',


### PR DESCRIPTION
All the deployments expect ports to be allocated to 8080 by default. 