### PR TITLE
Resolved task emails now say approved rather than granted

### DIFF
--- a/lib/content.js
+++ b/lib/content.js
@@ -40,7 +40,7 @@ module.exports = {
     'referred-to-inspector': 'Awaiting recommendation',
     'inspector-recommended': 'Recommendation made',
     'inspector-rejected': 'Recommendation made',
-    resolved: 'Granted',
+    resolved: 'Approved',
     rejected: 'Rejected'
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3275,10 +3275,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",


### PR DESCRIPTION
The task "status change" email was saying "Granted" for resolved tasks, even if that task was revoke.

It should now say Approved which will do as a stopgap until we add more specific emails.