### PR TITLE
Add notification support for PIL transfers

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -17,6 +17,10 @@ module.exports = settings => {
       return Promise.resolve('revocation');
     }
 
+    if (get(task, 'action') === 'transfer') {
+      return Promise.resolve('transfer');
+    }
+
     if (get(task, 'modelData.status') === 'active') {
       return Promise.resolve('amendment');
     }

--- a/lib/content.js
+++ b/lib/content.js
@@ -3,7 +3,8 @@ module.exports = {
     pil: {
       application: 'PIL application',
       amendment: 'PIL amendment',
-      revocation: 'PIL revocation'
+      revocation: 'PIL revocation',
+      transfer: 'PIL transfer'
     },
     ppl: {
       application: 'PPL application',
@@ -22,7 +23,8 @@ module.exports = {
     pil: {
       application: 'Applicant name',
       amendment: 'Licence holder name',
-      revocation: 'Licence holder name'
+      revocation: 'Licence holder name',
+      transfer: 'Licence holder name'
     },
     ppl: {
       application: 'Project name',


### PR DESCRIPTION
This is a quick fix to get the correct text in the email for the current recipients (incoming NTCO, PIL applicant).

Further PRs will add notifications for outbound establishment HOLCs / NTCOs.