### PR TITLE
Ignore events which are not status changes

### DIFF
--- a/lib/recipients/index.js
+++ b/lib/recipients/index.js
@@ -12,10 +12,16 @@ const builders = {
 
 module.exports = ({ schema, logger }) => ({
   getNotifications: (task) => {
+    const event = get(task, 'event');
     const status = get(task, 'status');
     const model = get(task, 'data.model');
     const action = get(task, 'data.action');
     const isAutoresolvingProfileUpdate = status === 'autoresolved' && model === 'profile' && action === 'update';
+
+    if (!event.match(/^status:/)) {
+      logger.info(`ignoring non-status-change event '${task.event}'`);
+      return Promise.resolve(new Map());
+    }
 
     if (!isAutoresolvingProfileUpdate && taskHelper.ignore(task)) {
       logger.info(`ignoring task.status '${task.status}'`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
       "integrity": "sha1-hBl7B2mAr7V6tyNcXtzK890V/Mg="
     },
     "@asl/schema": {
-      "version": "7.24.3",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-7.24.3.tgz",
-      "integrity": "sha1-YFfw/OdOYPR+dXUP3GqzdTYBmZs=",
+      "version": "7.25.6",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-7.25.6.tgz",
+      "integrity": "sha1-uvnU4ryYCBks/HeCNgLHVVx0gEE=",
       "requires": {
         "@asl/constants": "^0.3.2",
         "knex": "^0.19.5",
@@ -6092,14 +6092,15 @@
       }
     },
     "pg": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-7.14.0.tgz",
-      "integrity": "sha512-TLsdOWKFu44vHdejml4Uoo8h0EwCjdIj9Z9kpz7pA5i8iQxOTwVb1+Fy+X86kW5AXKxQpYpYDs4j/qPDbro/lg==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.17.0.tgz",
+      "integrity": "sha512-70Q4ZzIdPgwMPb3zUIzAUwigNJ4v5vsWdMED6OzXMfOECeYTvTm7iSC3FpKizu/R1BHL8Do3bLs6ltGfOTAnqg==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
         "pg-connection-string": "0.1.3",
-        "pg-pool": "^2.0.7",
+        "pg-packet-stream": "^1.1.0",
+        "pg-pool": "^2.0.9",
         "pg-types": "^2.1.0",
         "pgpass": "1.x",
         "semver": "4.3.2"
@@ -6123,26 +6124,31 @@
       "integrity": "sha512-bhlV7Eq09JrRIvo1eKngpwuqKtJnNhZdpdOlvrPrA4dxqXPjxSrbNrfnIDmTpwMyRszrcV4kU5ZA4mMsQUrjdg=="
     },
     "pg-cursor": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.0.1.tgz",
-      "integrity": "sha512-AfPaRh6N32HrXB8/D0JXfJWdLCn8U+Z4LEf8C954aSFTjhZqt7QbyAYyN5k1E4cv0HQjwW70G1xywQ5ZECzPPg=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.1.2.tgz",
+      "integrity": "sha512-qYTrDmuEQRX2MwtqA25jA/WXMjdZyTDZoBDhgPvPrYTWZTJjcoR+8fdhNUY2+iik3qJ3LMfH7+nZGmJFP4Q4rA=="
     },
     "pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
+    "pg-packet-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pg-packet-stream/-/pg-packet-stream-1.1.0.tgz",
+      "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
+    },
     "pg-pool": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.7.tgz",
-      "integrity": "sha512-UiJyO5B9zZpu32GSlP0tXy8J2NsJ9EFGFfz5v6PSbdz/1hBLX1rNiiy5+mAm5iJJYwfCv4A0EBcQLGWwjbpzZw=="
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.9.tgz",
+      "integrity": "sha512-gNiuIEKNCT3OnudQM2kvgSnXsLkSpd6mS/fRnqs6ANtrke6j8OY5l9mnAryf1kgwJMWLg0C1N1cYTZG1xmEYHQ=="
     },
     "pg-query-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-2.0.1.tgz",
-      "integrity": "sha512-yiAbAkZHe3lgoQt0BdhqVe0KJ2ggB9yAUzpiNrbRpvolBMFIeO/RNsbR+V3Opigk2YiXNc1rjsTHLAd0Sj1iMg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-2.1.2.tgz",
+      "integrity": "sha512-xdF/xpn6foUk9HL1ptdP4NwZ2bzKuU0UldvkZ6++vAzNSIL+RBBmhgb59XA1vR2+TwCmFXskVwRz1876+0LH7Q==",
       "requires": {
-        "pg-cursor": "^2.0.1"
+        "pg-cursor": "^2.1.2"
       }
     },
     "pg-types": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "nodemon": "^1.18.10"
   },
   "dependencies": {
-    "@asl/schema": "^7.24.3",
+    "@asl/schema": "^7.25.6",
     "@asl/service": "^7.13.0",
     "lodash": "^4.17.15",
     "mustache": "^3.1.0",

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -20,8 +20,35 @@ describe('Notification list', () => {
     return this.schema.destroy();
   });
 
+  it('returns empty if the event is a comment', () => {
+    const task = { event: 'comment', status: 'with-inspectorate', model: 'project', action: 'grant' };
+
+    return this.recipientBuilder.getNotifications(task)
+      .then(recipients => {
+        assert(isEmpty(recipients), 'do not notify users of comments');
+      });
+  });
+
+  it('returns empty if the event is a comment edit', () => {
+    const task = { event: 'edit-comment', status: 'with-inspectorate', model: 'project', action: 'grant' };
+
+    return this.recipientBuilder.getNotifications(task)
+      .then(recipients => {
+        assert(isEmpty(recipients), 'do not notify users of comments');
+      });
+  });
+
+  it('returns empty if the event is a comment deletion', () => {
+    const task = { event: 'delete-comment', status: 'with-inspectorate', model: 'project', action: 'grant' };
+
+    return this.recipientBuilder.getNotifications(task)
+      .then(recipients => {
+        assert(isEmpty(recipients), 'do not notify users of comments');
+      });
+  });
+
   it('returns empty if the task status is an ignored status', () => {
-    const task = { status: 'resubmitted', model: 'establishment' };
+    const task = { event: 'status:returned-to-applicant:resubmitted', status: 'resubmitted', model: 'establishment' };
 
     return this.recipientBuilder.getNotifications(task)
       .then(recipients => {
@@ -30,7 +57,7 @@ describe('Notification list', () => {
   });
 
   it('returns empty if there is no model present in the task', () => {
-    const task = { status: 'not-a-valid-task', model: null };
+    const task = { event: 'status:returned-to-applicant:resubmitted', status: 'not-a-valid-task', model: null };
 
     return this.recipientBuilder.getNotifications(task)
       .then(recipients => {


### PR DESCRIPTION
Currently all comment-related events are triggering notifications, which results in a large volume of unnecessary email.

Only allow notifications for status change events.