### PR TITLE
Don't send notifications for autoresolved profile updates

### DIFF
--- a/lib/recipients/profile.js
+++ b/lib/recipients/profile.js
@@ -35,8 +35,6 @@ module.exports = ({ schema, logger, task }) => {
       logger.debug(`applicant is ${applicant.firstName} ${applicant.lastName}`);
 
       if (taskHelper.isAutoresolved(task) && action === 'update' && !initiatedByAsru) {
-        logger.verbose('profile update was autoresolved, notifying applicant only');
-        notifications.set(applicantId, { emailTemplate: 'profile-updated', applicant, recipient: applicant });
         return;
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,9 +33,9 @@
       }
     },
     "@asl/constants": {
-      "version": "0.6.1",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/constants/-/@asl/constants-0.6.1.tgz",
-      "integrity": "sha1-KPF4ywKMa9lIbbV6Olp76KlJbMo="
+      "version": "0.7.1",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/constants/-/@asl/constants-0.7.1.tgz",
+      "integrity": "sha1-0Egr+PlwqN4uGjeqbXyqEJnxUxE="
     },
     "@asl/dictionary": {
       "version": "1.1.4",
@@ -43,16 +43,17 @@
       "integrity": "sha1-hBl7B2mAr7V6tyNcXtzK890V/Mg="
     },
     "@asl/schema": {
-      "version": "7.32.5",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-7.32.5.tgz",
-      "integrity": "sha1-bKfvaSb4CWAtdp4tbJvNNCesTD0=",
+      "version": "7.40.2",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-7.40.2.tgz",
+      "integrity": "sha1-tqn2UuZlUuYSocqX8q1rzKc7kXU=",
       "requires": {
-        "@asl/constants": "^0.6.1",
+        "@asl/constants": "^0.7.1",
+        "deep-diff": "^1.0.2",
         "knex": "^0.19.5",
         "lodash": "^4.17.15",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.3",
         "moment": "^2.22.2",
-        "objection": "^1.2.0",
+        "objection": "^2.1.3",
         "pg": "^7.4.1",
         "pg-query-stream": "^2.0.1",
         "uuid": "^3.3.2"
@@ -62,6 +63,11 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
           "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+        },
+        "deep-diff": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.2.tgz",
+          "integrity": "sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg=="
         },
         "inherits": {
           "version": "2.0.4",
@@ -2263,6 +2269,11 @@
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+    },
+    "db-errors": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/db-errors/-/db-errors-0.2.3.tgz",
+      "integrity": "sha512-OOgqgDuCavHXjYSJoV2yGhv6SeG8nk42aoCSoyXLZUH7VwFG27rxbavU1z+VrZbZjphw5UkDQwUlD21MwZpUng=="
     },
     "debug": {
       "version": "4.1.1",
@@ -5828,13 +5839,12 @@
       }
     },
     "objection": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/objection/-/objection-1.6.11.tgz",
-      "integrity": "sha512-/W6iR6+YvFg1U4k5DyX1MrY+xqodDM8AAOU1J0b3HlptsNw8V3uDHjZgTi1cFPPe5+ZeTTMvhIFhNiUP6+nqYQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/objection/-/objection-2.1.3.tgz",
+      "integrity": "sha512-aKr28HntHoX6wPiFw3BWLx0Ufqmu4h4Ygj/xCYgFXrgftxB7+lWtAA/J13zcLlSmLl9Jifs6HEJFMjFrbH358w==",
       "requires": {
-        "ajv": "^6.10.0",
-        "bluebird": "^3.5.5",
-        "lodash": "^4.17.11"
+        "ajv": "^6.10.2",
+        "db-errors": "^0.2.3"
       },
       "dependencies": {
         "ajv": {
@@ -6129,9 +6139,9 @@
       "integrity": "sha512-bhlV7Eq09JrRIvo1eKngpwuqKtJnNhZdpdOlvrPrA4dxqXPjxSrbNrfnIDmTpwMyRszrcV4kU5ZA4mMsQUrjdg=="
     },
     "pg-cursor": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.1.6.tgz",
-      "integrity": "sha512-61En061/NFsfKOY0EvIdcl1l2FDvoeFSD2RLe57qA0rX0TbNxQ1TK9JOZaTTKrxk6L8opiHAv/IRAoHFMacKEQ=="
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.1.9.tgz",
+      "integrity": "sha512-ReAyfc0fiSzO268DZWtOoeUmMdMG368e7qu3zfwa7TpCjEmabk2XfZn+tdE23XzVlJ4OsdsFcxjASOWC0SS7jA=="
     },
     "pg-int8": {
       "version": "1.0.1",
@@ -6215,9 +6225,9 @@
       "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
     },
     "postgres-date": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.4.tgz",
-      "integrity": "sha512-bESRvKVuTrjoBluEcpv2346+6kgB7UlnqWZsnbnCccTNq/pqfj1j6oBaN5+b/NrDXepYUT/HKadqv3iS9lJuVA=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.5.tgz",
+      "integrity": "sha512-pdau6GRPERdAYUQwkBnGKxEfPyhVZXG/JiS44iZWiNdSOWE09N2lUgN6yshuq6fVSon4Pm0VMXd1srUUkLe9iA=="
     },
     "postgres-interval": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "nodemon -r dotenv/config index.js",
     "test": "npm run test:lint && npm run test:unit",
     "test:lint": "eslint .",
-    "pretest:unit": "npm run migrate",
+    "pretest:unit": "NODE_ENV=test npm run migrate",
     "test:unit": "NODE_ENV=test mocha ./test --recursive --exit --timeout 5000",
     "migrate": "DATABASE_NAME=asl-test knex migrate:latest --knexfile ./node_modules/@asl/schema/knexfile.js"
   },
@@ -32,7 +32,7 @@
     "nodemon": "^1.18.10"
   },
   "dependencies": {
-    "@asl/schema": "^7.32.5",
+    "@asl/schema": "^7.40.2",
     "@asl/service": "^7.13.0",
     "lodash": "^4.17.15",
     "mustache": "^3.1.0",

--- a/test/helpers/db.js
+++ b/test/helpers/db.js
@@ -8,7 +8,7 @@ const dbConfig = {
     database: process.env.DATABASE_NAME || 'asl-test',
     host: process.env.DATABASE_HOST || 'localhost',
     user: process.env.DATABASE_USERNAME || 'postgres',
-    password: process.env.DATABASE_PASSWORD
+    password: process.env.DATABASE_PASSWORD || 'test-password'
   }
 };
 

--- a/test/specs/models/profile/amendment.js
+++ b/test/specs/models/profile/amendment.js
@@ -32,11 +32,10 @@ describe('Profile amendment', () => {
 
     describe('Applicant', () => {
 
-      it('notifies the profile owner that the change has been made', () => {
+      it('does not notify the profile owner that the change has been made', () => {
         return this.recipientBuilder.getNotifications(profileAmendmentAutoresolved)
           .then(recipients => {
-            assert(recipients.has(basic), 'basic is in the recipients list');
-            assert(recipients.get(basic).emailTemplate === 'profile-updated', 'email type is profile-updated');
+            assert(!recipients.has(basic), 'basic is not in the recipients list');
           });
       });
 


### PR DESCRIPTION
These result in multiple emails when the update is an email change, which are notified separately, as well as containing useless information by linking to an autoresolved task.

If we think this _should_ send a notification then it should send a better notification.