### PR TITLE
Fix ignored statuses

### DIFF
--- a/lib/dispatcher/content.js
+++ b/lib/dispatcher/content.js
@@ -56,6 +56,7 @@ module.exports = {
     new: 'Draft',
     'resubmitted': 'Resubmitted',
     'returned-to-applicant': 'Returned',
+    'recalled-by-applicant': 'Recalled',
     'withdrawn-by-applicant': 'Withdrawn',
     'discarded-by-applicant': 'Withdrawn',
     'with-ntco': 'Awaiting endorsement',

--- a/lib/recipients/index.js
+++ b/lib/recipients/index.js
@@ -21,13 +21,13 @@ module.exports = ({ schema, logger }) => ({
       return Promise.resolve(new Map());
     }
 
-    if (taskHelper.isIgnoredStatus(task)) {
-      logger.info(`ignoring task.status '${task.status}'`);
+    if (!model || !builders[model]) {
+      logger.info(`recipient list could not be determined for model '${model}'`);
       return Promise.resolve(new Map());
     }
 
-    if (!model || !builders[model]) {
-      logger.info(`recipient list could not be determined for model '${model}'`);
+    if (taskHelper.isIgnoredStatus(task)) {
+      logger.info(`ignoring task.status '${task.status}'`);
       return Promise.resolve(new Map());
     }
 

--- a/lib/utils/task.js
+++ b/lib/utils/task.js
@@ -55,7 +55,7 @@ module.exports = {
   },
 
   isIgnoredStatus: task => {
-    return ignoredStatuses.includes(task.status);
+    return ignoredStatuses.includes(task.meta.next);
   },
 
   isTransfer: task => {

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -48,7 +48,7 @@ describe('Notification list', () => {
   });
 
   it('returns empty if the task status is an ignored status', () => {
-    const task = { event: 'status:returned-to-applicant:resubmitted', status: 'resubmitted', model: 'establishment' };
+    const task = { event: 'status:returned-to-applicant:resubmitted', status: 'with-inspectorate', model: 'establishment', meta: { previous: 'returned-to-applicant', next: 'resubmitted' } };
 
     return this.recipientBuilder.getNotifications(task)
       .then(recipients => {
@@ -57,7 +57,7 @@ describe('Notification list', () => {
   });
 
   it('returns empty if there is no model present in the task', () => {
-    const task = { event: 'status:returned-to-applicant:resubmitted', status: 'not-a-valid-task', model: null };
+    const task = { event: 'status:returned-to-applicant:resubmitted', status: 'not-a-valid-task', model: null, meta: { previous: 'returned-to-applicant', next: 'resubmitted' } };
 
     return this.recipientBuilder.getNotifications(task)
       .then(recipients => {


### PR DESCRIPTION
Check for if a status change should trigger a notification was using the `status` property, which in the case where a single workflow request triggers multiple status changes (i.e. 100% of the times we need to ignore a change) is always the _final_ status of the task.

Instead check the `meta.next` property on the task, which contains the value of the status for the particular change that is being responded to in each request.