### PR TITLE
Fix identifier value in profile notifications

### DIFF
--- a/lib/dispatcher/get-identifier.js
+++ b/lib/dispatcher/get-identifier.js
@@ -1,14 +1,15 @@
 module.exports = ({ model, licenceType, applicant }) => {
+
   switch (licenceType) {
     case 'profile':
     case 'pil':
       return `${applicant.firstName} ${applicant.lastName}`;
 
     case 'pel':
-      return model.name;
+      return model && model.name;
 
     case 'ppl':
-      return model.title;
+      return model && model.title;
   }
   return '';
 };

--- a/lib/dispatcher/index.js
+++ b/lib/dispatcher/index.js
@@ -36,7 +36,7 @@ module.exports = ({ schema, emailer, logger, publicUrl }) => async ({ task, noti
       grantType: get(content, `grantType[${taskType}]`),
       taskType: get(content, `type[${licenceType}][${taskType}]`),
       identifier: get(content, `identifier[${licenceType}][${taskType}]`),
-      identifierValue: model && getIdentifier({ model, licenceType, applicant }),
+      identifierValue: getIdentifier({ model, licenceType, applicant }),
       prevStatus: get(content, `status[${task.meta.previous}]`),
       newStatus: get(content, `status[${task.meta.next}]`),
       taskUrl: `${publicUrl}/tasks/${task.id}`,


### PR DESCRIPTION
Because no model is loaded for profiles the check for existence of `model` where it was prevented the loading of an identifier. Instead move the `model` check into the relevant parts of the `getIdentifier` function.