### PR TITLE
Reduce size of error payload

### DIFF
--- a/lib/dispatcher/index.js
+++ b/lib/dispatcher/index.js
@@ -60,6 +60,7 @@ module.exports = ({ schema, emailer, logger, publicUrl }) => async ({ task, noti
       })
       .catch(e => {
         e.task = {
+          id: task.id,
           licenceType,
           taskType,
           event: task.event

--- a/lib/dispatcher/index.js
+++ b/lib/dispatcher/index.js
@@ -59,7 +59,11 @@ module.exports = ({ schema, emailer, logger, publicUrl }) => async ({ task, noti
         });
       })
       .catch(e => {
-        e.task = task;
+        e.task = {
+          licenceType,
+          taskType,
+          event: task.event
+        };
         throw e;
       });
   }));


### PR DESCRIPTION
Logs contained potentially sensitive information. Only log the minimal data needed to debug.