### PR TITLE
Always send "amendment" notifications for places

### DIFF
--- a/lib/dispatcher/content.js
+++ b/lib/dispatcher/content.js
@@ -77,6 +77,7 @@ module.exports = {
     'task-action': 'Action required',
     'task-change': 'Status change',
     'task-outgoing': 'Status change',
-    'licence-granted': 'Licence granted'
+    'licence-granted': 'Licence granted',
+    'licence-amended': 'Licence amended'
   }
 };

--- a/lib/dispatcher/get-task-type.js
+++ b/lib/dispatcher/get-task-type.js
@@ -20,7 +20,7 @@ module.exports = task => {
     return 'amendment';
   }
 
-  if (['role', 'place'].includes(model) && ['create', 'delete'].includes(action)) {
+  if (['role', 'place'].includes(model)) {
     return 'amendment';
   }
 

--- a/lib/dispatcher/templates/licence-amended.js
+++ b/lib/dispatcher/templates/licence-amended.js
@@ -1,0 +1,1 @@
+module.exports = require('./licence-granted');

--- a/lib/recipients/establishment.js
+++ b/lib/recipients/establishment.js
@@ -38,7 +38,8 @@ module.exports = ({ schema, logger, task }) => {
 
       } else if (taskHelper.isGranted(task)) {
         logger.verbose('licence granted, notifying applicant');
-        notifications.set(applicantId, { emailTemplate: 'licence-granted', applicant, recipient: applicant });
+        const template = ['place', 'role'].includes(model) ? 'licence-amended' : 'licence-granted';
+        notifications.set(applicantId, { emailTemplate: template, applicant, recipient: applicant });
 
       } else if (taskHelper.isClosed(task)) {
         logger.verbose('task is closed, notifying applicant');
@@ -60,7 +61,8 @@ module.exports = ({ schema, logger, task }) => {
 
                 } else if (taskHelper.isGranted(task)) {
                   logger.verbose('licence granted, notifying admin');
-                  notifications.set(profile.id, { emailTemplate: 'licence-granted', applicant, recipient: profile });
+                  const template = ['place', 'role'].includes(model) ? 'licence-amended' : 'licence-granted';
+                  notifications.set(profile.id, { emailTemplate: template, applicant, recipient: profile });
 
                 } else if (taskHelper.isClosed(task)) {
                   logger.verbose('task is closed, notifying admin');

--- a/lib/utils/task.js
+++ b/lib/utils/task.js
@@ -72,10 +72,8 @@ module.exports = {
 
     switch (model) {
       case 'place':
-        return ['create', 'update'].includes(action);
-
       case 'role':
-        return ['create', 'delete'].includes(action);
+        return true;
 
       case 'pil':
       case 'project':

--- a/test/specs/models/place/update.js
+++ b/test/specs/models/place/update.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { merge } = require('lodash');
 const dbHelper = require('../../../helpers/db');
 const logger = require('../../../helpers/logger');
 const Recipients = require('../../../../lib/recipients');
@@ -11,7 +12,11 @@ const {
   pelAmendmentRejected
 } = require('../../../data/tasks');
 
-describe('Place create (Establishment amendment)', () => {
+const makeUpdate = task => {
+  return merge({}, task, { data: { action: 'update' } });
+};
+
+describe('Place update (Establishment amendment)', () => {
 
   before(() => {
     this.schema = dbHelper.init();
@@ -30,7 +35,7 @@ describe('Place create (Establishment amendment)', () => {
   describe('Applicant', () => {
 
     it('notifies the applicant when the amendment lands with ASRU', () => {
-      return this.recipientBuilder.getNotifications(pelAmendmentSubmitted)
+      return this.recipientBuilder.getNotifications(makeUpdate(pelAmendmentSubmitted))
         .then(recipients => {
           assert(recipients.has(croydonAdmin1), 'croydonAdmin1 is in the recipients list');
           assert(recipients.get(croydonAdmin1).emailTemplate === 'task-with-asru', 'email type is task-with-asru');
@@ -39,14 +44,14 @@ describe('Place create (Establishment amendment)', () => {
     });
 
     it('does not notify the applicant when moving between inspectors and licensing', () => {
-      return this.recipientBuilder.getNotifications(pelAmendmentApproved)
+      return this.recipientBuilder.getNotifications(makeUpdate(pelAmendmentApproved))
         .then(recipients => {
           assert(!recipients.has(croydonAdmin1), 'croydonAdmin1 is not in the recipients list');
         });
     });
 
     it('notifies the applicant when the amendment is granted', () => {
-      return this.recipientBuilder.getNotifications(pelAmendmentGranted)
+      return this.recipientBuilder.getNotifications(makeUpdate(pelAmendmentGranted))
         .then(recipients => {
           assert(recipients.has(croydonAdmin1), 'croydonAdmin1 is in the recipients list');
           assert(recipients.get(croydonAdmin1).emailTemplate === 'licence-amended', 'email type is licence-amended');
@@ -55,7 +60,7 @@ describe('Place create (Establishment amendment)', () => {
     });
 
     it('notifies the applicant when the amendment is rejected', () => {
-      return this.recipientBuilder.getNotifications(pelAmendmentRejected)
+      return this.recipientBuilder.getNotifications(makeUpdate(pelAmendmentRejected))
         .then(recipients => {
           assert(recipients.has(croydonAdmin1), 'croydonAdmin1 is in the recipients list');
           assert(recipients.get(croydonAdmin1).emailTemplate === 'task-closed', 'email type is task-closed');
@@ -68,7 +73,7 @@ describe('Place create (Establishment amendment)', () => {
   describe('Establishment admins', () => {
 
     it('does not override the applicant email if the applicant is also an admin', () => {
-      return this.recipientBuilder.getNotifications(pelAmendmentSubmitted)
+      return this.recipientBuilder.getNotifications(makeUpdate(pelAmendmentSubmitted))
         .then(recipients => {
           assert(recipients.has(croydonAdmin1), 'croydonAdmin1 is in the recipients list');
           assert(recipients.get(croydonAdmin1).emailTemplate === 'task-with-asru', 'email type is task-with-asru');
@@ -76,7 +81,7 @@ describe('Place create (Establishment amendment)', () => {
     });
 
     it('notifies other admins at the establishment when the amendment lands with ASRU', () => {
-      return this.recipientBuilder.getNotifications(pelAmendmentSubmitted)
+      return this.recipientBuilder.getNotifications(makeUpdate(pelAmendmentSubmitted))
         .then(recipients => {
           assert(recipients.has(croydonAdmin2), 'croydonAdmin2 is in the recipients list');
           assert(recipients.get(croydonAdmin2).emailTemplate === 'task-with-asru', 'email type is task-with-asru');
@@ -85,14 +90,14 @@ describe('Place create (Establishment amendment)', () => {
     });
 
     it('does not notify other admins at the establishment when moving between inspectors and licensing', () => {
-      return this.recipientBuilder.getNotifications(pelAmendmentApproved)
+      return this.recipientBuilder.getNotifications(makeUpdate(pelAmendmentApproved))
         .then(recipients => {
           assert(!recipients.has(croydonAdmin2), 'croydonAdmin2 is not in the recipients list');
         });
     });
 
     it('notifies other admins at the establishment when the amendment is granted', () => {
-      return this.recipientBuilder.getNotifications(pelAmendmentGranted)
+      return this.recipientBuilder.getNotifications(makeUpdate(pelAmendmentGranted))
         .then(recipients => {
           assert(recipients.has(croydonAdmin2), 'research101Admin2 is in the recipients list');
           assert(recipients.get(croydonAdmin2).emailTemplate === 'licence-amended', 'email type is licence-amended');
@@ -101,7 +106,7 @@ describe('Place create (Establishment amendment)', () => {
     });
 
     it('notifies other admins at the establishment when the amendment is rejected', () => {
-      return this.recipientBuilder.getNotifications(pelAmendmentRejected)
+      return this.recipientBuilder.getNotifications(makeUpdate(pelAmendmentRejected))
         .then(recipients => {
           assert(recipients.has(croydonAdmin2), 'croydonAdmin2 is in the recipients list');
           assert(recipients.get(croydonAdmin2).emailTemplate === 'task-closed', 'email type is task-closed');


### PR DESCRIPTION
`update` actions on places were sending as "granted" notifications which is wildly misleading. Ensure that changes to roles and places always send as amendments irrespective of the action.