### PR TITLE
Don't notify for autoresolved profile updates by ASRU

### DIFF
--- a/lib/recipients/profile.js
+++ b/lib/recipients/profile.js
@@ -8,7 +8,7 @@ module.exports = ({ schema, logger, task }) => {
   const { Profile } = schema;
   const applicantId = get(task, 'data.subject');
   const action = get(task, 'data.action');
-  const initiatedByAsru = get(task, 'data.initiatedByAsru');
+
   const allowedActions = ['update'];
 
   const getAdmins = establishmentIds => Profile.query()
@@ -34,7 +34,7 @@ module.exports = ({ schema, logger, task }) => {
     .then(applicant => {
       logger.debug(`applicant is ${applicant.firstName} ${applicant.lastName}`);
 
-      if (taskHelper.isAutoresolved(task) && action === 'update' && !initiatedByAsru) {
+      if (taskHelper.isAutoresolved(task)) {
         return;
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
       "integrity": "sha1-hBl7B2mAr7V6tyNcXtzK890V/Mg="
     },
     "@asl/schema": {
-      "version": "7.45.4",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-7.45.4.tgz",
-      "integrity": "sha1-ke7CimljkO1vPGuMBUf6OPSvQ88=",
+      "version": "7.48.1",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-7.48.1.tgz",
+      "integrity": "sha1-IRh76l3YG5Q/CR5DAKoQIKLqKBQ=",
       "requires": {
         "@asl/constants": "^0.7.1",
         "csv-stringify": "^5.4.3",
@@ -79,9 +79,9 @@
           "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "interpret": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-          "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+          "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
         },
         "knex": {
           "version": "0.19.5",
@@ -5693,9 +5693,9 @@
       "dev": true
     },
     "nise": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.3.tgz",
-      "integrity": "sha512-EGlhjm7/4KvmmE6B/UFsKh7eHykRl9VH+au8dduHLCyWUO/hr7+N+WtTvDUwc9zHuM1IaIJs/0lQ6Ag1jDkQSg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
       "requires": {
         "@sinonjs/commons": "^1.7.0",
         "@sinonjs/fake-timers": "^6.0.0",
@@ -5940,18 +5940,18 @@
       }
     },
     "objection": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/objection/-/objection-2.1.5.tgz",
-      "integrity": "sha512-y4wyMHy0zByvcXPL+A2wD7wVRUnn/b9r+D6ms2LSmQSwo2WPoifwOOdwkyIGZ6312bp2YgzuEoAG/xv44RKevA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/objection/-/objection-2.2.1.tgz",
+      "integrity": "sha512-VY/OGLlLpHwIHck9/HC9meSpjE9w2b4ufxDu/igVCowyDajmcU3AwRmaqKQP8MhMCLPZKSj8gqIAQ5m5zpV5YA==",
       "requires": {
         "ajv": "^6.12.0",
         "db-errors": "^0.2.3"
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "version": "6.12.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -5960,9 +5960,9 @@
           }
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         }
       }
     },
@@ -6240,9 +6240,9 @@
       "integrity": "sha512-bhlV7Eq09JrRIvo1eKngpwuqKtJnNhZdpdOlvrPrA4dxqXPjxSrbNrfnIDmTpwMyRszrcV4kU5ZA4mMsQUrjdg=="
     },
     "pg-cursor": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.2.1.tgz",
-      "integrity": "sha512-C0DKcb8do7Mv9tTQvrB+hxPYgJ6FCKnu1CjPMb0txYHW+zULpOH0B01MNtjQA4nrhHJ4Qs1Nf58BGEc158wXIA=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.2.2.tgz",
+      "integrity": "sha512-EpWTwt575oDUriFhzv8Asu2zciD0Z7sopgOJTjsMzGCLEGvRPTgQmHFyo8Omhd/NArX/GELZO5Jh/halIrsgXw=="
     },
     "pg-int8": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "nodemon": "^1.18.10"
   },
   "dependencies": {
-    "@asl/schema": "^7.45.4",
+    "@asl/schema": "^7.48.1",
     "@asl/service": "^7.13.0",
     "lodash": "^4.17.15",
     "mustache": "^3.1.0",


### PR DESCRIPTION
ASRU users are currently being sent emails linking to tasks when their roles change or they get added to ASRU. These tasks don't have meaningful task pages so the users are clicking the links and getting an error page (and we're getting an alert).

Rather than sending a user a meaningles email disable it completely.

There is no context I can think of where a non-ASRU user would have their profile updated with `initiatedByAsru` so I'm confident it is legit to completely turn these off.