### PR TITLE
Ignore autoresolved tasks

### DIFF
--- a/lib/recipients/pil.js
+++ b/lib/recipients/pil.js
@@ -52,7 +52,6 @@ module.exports = ({ schema, logger, task }) => {
       if (taskHelper.isNew(task)) {
         logger.verbose('task is new, notifying applicant');
         notifications.set(applicantId, { emailTemplate: 'task-opened', applicant, recipient: applicant });
-
       } else if (taskHelper.isWithApplicant(task)) {
         logger.verbose('task is with applicant, notifying applicant');
         notifications.set(applicantId, { emailTemplate: 'task-action-required', applicant, recipient: applicant });

--- a/lib/utils/task.js
+++ b/lib/utils/task.js
@@ -2,9 +2,9 @@ const { get } = require('lodash');
 
 const newStatuses = ['new'];
 
-const closedStatuses = ['resolved', 'autoresolved', 'rejected', 'discarded-by-applicant', 'withdrawn-by-applicant'];
+const closedStatuses = ['resolved', 'rejected', 'discarded-by-applicant', 'withdrawn-by-applicant'];
 
-const resolvedStatuses = ['resolved', 'autoresolved'];
+const resolvedStatuses = ['resolved'];
 
 const withApplicantStatuses = ['returned-to-applicant', 'recalled-by-applicant'];
 
@@ -14,7 +14,7 @@ const withAdminStatuses = ['awaiting-endorsement'];
 
 const withAsruStatuses = ['with-licensing', 'with-inspectorate', 'referred-to-inspector', 'inspector-recommended', 'inspector-rejected'];
 
-const ignoredStatuses = ['endorsed', 'updated', 'resubmitted'];
+const ignoredStatuses = ['endorsed', 'updated', 'resubmitted', 'autoresolved'];
 
 module.exports = {
   newStatuses,
@@ -27,7 +27,7 @@ module.exports = {
   ignoredStatuses,
 
   isNew: task => {
-    return newStatuses.includes(task.meta.previous) && task.meta.next !== 'autoresolved';
+    return newStatuses.includes(task.meta.previous) && !closedStatuses.includes(task.meta.next);
   },
 
   isClosed: task => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,9 +37,9 @@
       "integrity": "sha1-zAfMVkySkCf0sdfp7o0vVEv5KLs="
     },
     "@asl/schema": {
-      "version": "8.0.1",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-8.0.1.tgz",
-      "integrity": "sha1-8Se+5tgijCuQmgnmzZGEQWue+6s=",
+      "version": "8.3.3",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-8.3.3.tgz",
+      "integrity": "sha1-PQC18Qw7yK1/vmv7oc491t/14Uk=",
       "requires": {
         "@asl/constants": "^0.7.1",
         "csv-stringify": "^5.4.3",
@@ -1415,9 +1415,9 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",
-      "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.1.0.tgz",
+      "integrity": "sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==",
       "requires": {
         "@sinonjs/commons": "^1.6.0",
         "lodash.get": "^4.4.2",
@@ -5098,9 +5098,9 @@
       }
     },
     "just-extend": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
-      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA=="
     },
     "jwk-to-pem": {
       "version": "2.0.4",
@@ -6044,9 +6044,9 @@
       }
     },
     "objection": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/objection/-/objection-2.2.2.tgz",
-      "integrity": "sha512-+1Ap7u9NQRochzDW5/BggUlKi94JfZGTJwQJuNXo8DwmAb8czEirvxcWBcX91/MmQq0BQUJjM4RPSiZhnkkWQw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/objection/-/objection-2.2.3.tgz",
+      "integrity": "sha512-uNya9GuHlNeix7H0URthVE3+CmAlXmxkU69LAcRnncLjujJ8l1YX8JCB2GVSErTYS3Oc2xneF1ZWaR/MS8r63g==",
       "requires": {
         "ajv": "^6.12.0",
         "db-errors": "^0.2.3"
@@ -6341,9 +6341,9 @@
       "integrity": "sha512-bhlV7Eq09JrRIvo1eKngpwuqKtJnNhZdpdOlvrPrA4dxqXPjxSrbNrfnIDmTpwMyRszrcV4kU5ZA4mMsQUrjdg=="
     },
     "pg-cursor": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.3.0.tgz",
-      "integrity": "sha512-9vOHIWz8T3BWDfif7CDeZVjXUhRv4qOz/FDxolNBBU6AYgK2GThxOYsY6vmNJWuA61rtRrpAorO+LyX9X3o/4A=="
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.3.3.tgz",
+      "integrity": "sha512-0hwZEd+gjDGgN42BFYOp2fVLyKUbk8jjDyO/PLU34W19shoh/qnCDAUzfa4+IhUGjAgN0r/xIT3pANT946zaFg=="
     },
     "pg-int8": {
       "version": "1.0.1",
@@ -6431,9 +6431,9 @@
       "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
     },
     "postgres-date": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.5.tgz",
-      "integrity": "sha512-pdau6GRPERdAYUQwkBnGKxEfPyhVZXG/JiS44iZWiNdSOWE09N2lUgN6yshuq6fVSon4Pm0VMXd1srUUkLe9iA=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
     },
     "postgres-interval": {
       "version": "1.2.0",
@@ -7261,16 +7261,16 @@
       }
     },
     "sinon": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.2.tgz",
-      "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.3.tgz",
+      "integrity": "sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==",
       "requires": {
         "@sinonjs/commons": "^1.7.2",
         "@sinonjs/fake-timers": "^6.0.1",
         "@sinonjs/formatio": "^5.0.1",
-        "@sinonjs/samsam": "^5.0.3",
+        "@sinonjs/samsam": "^5.1.0",
         "diff": "^4.0.2",
-        "nise": "^4.0.1",
+        "nise": "^4.0.4",
         "supports-color": "^7.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "nodemon": "^2.0.4"
   },
   "dependencies": {
-    "@asl/schema": "^8.0.1",
+    "@asl/schema": "^8.3.3",
     "@asl/service": "^7.13.0",
     "lodash": "^4.17.19",
     "mustache": "^3.1.0",

--- a/test/data/tasks/pil/pil-amendment-asru.js
+++ b/test/data/tasks/pil/pil-amendment-asru.js
@@ -2,7 +2,7 @@ module.exports = {
   id: '884846c7-9901-462a-9dd0-b0001fad9368',
   meta: {
     previous: 'new',
-    next: 'autoresolved',
+    next: 'resolved',
     user: {
       id: 'dee8605d-2113-4411-8a0a-dc131af87a76',
       profile: {
@@ -34,8 +34,8 @@ module.exports = {
       changedBy: 'a942ffc7-e7ca-4d76-a001-0b5048a057d2'
     }
   },
-  event: 'status:new:autoresolved',
-  status: 'autoresolved',
+  event: 'status:new:resolved',
+  status: 'resolved',
   data: {
     id: '0c7ac573-f4c2-4f2e-b6a0-684d6d4a52d7',
     data: {

--- a/test/specs/models/pil/amendment.js
+++ b/test/specs/models/pil/amendment.js
@@ -28,20 +28,20 @@ describe('PIL amendments', () => {
       return this.recipientBuilder.getNotifications(pilAmendmentAsru)
         .then(recipients => {
           assert(recipients.has(basic), 'basic user is in the recipients list');
-          assert(recipients.get(basic).emailTemplate === 'licence-granted', 'email type is licence-granted');
-          assert(recipients.get(basic).applicant.id === basic, 'basic user is the applicant');
+          assert.equal(recipients.get(basic).emailTemplate, 'licence-granted', 'email type is licence-granted');
+          assert.equal(recipients.get(basic).applicant.id, basic, 'basic user is the applicant');
 
           assert(recipients.has(croydonAdmin1), 'croydonAdmin1 is in the recipients list');
-          assert(recipients.get(croydonAdmin1).emailTemplate === 'licence-granted', 'email type is licence-granted');
-          assert(recipients.get(croydonAdmin1).applicant.id === basic, 'basic user is the applicant');
+          assert.equal(recipients.get(croydonAdmin1).emailTemplate, 'licence-granted', 'email type is licence-granted');
+          assert.equal(recipients.get(croydonAdmin1).applicant.id, basic, 'basic user is the applicant');
 
           assert(recipients.has(croydonAdmin2), 'croydonAdmin2 is in the recipients list');
-          assert(recipients.get(croydonAdmin2).emailTemplate === 'licence-granted', 'email type is licence-granted');
-          assert(recipients.get(croydonAdmin2).applicant.id === basic, 'basic user is the applicant');
+          assert.equal(recipients.get(croydonAdmin2).emailTemplate, 'licence-granted', 'email type is licence-granted');
+          assert.equal(recipients.get(croydonAdmin2).applicant.id, basic, 'basic user is the applicant');
 
           assert(recipients.has(croydonNtco), 'croydonNtco is in the recipients list');
-          assert(recipients.get(croydonNtco).emailTemplate === 'licence-granted', 'email type is licence-granted');
-          assert(recipients.get(croydonNtco).applicant.id === basic, 'basic user is the applicant');
+          assert.equal(recipients.get(croydonNtco).emailTemplate, 'licence-granted', 'email type is licence-granted');
+          assert.equal(recipients.get(croydonNtco).applicant.id, basic, 'basic user is the applicant');
         });
     });
 


### PR DESCRIPTION
Any task that requires a notification should be set to `resolved` and not `autoresolved` so that as well as a notification it also leaves behind a related task.