### PR TITLE
Fix link in PIL notifications

### DIFF
--- a/lib/dispatcher/get-licence-path.js
+++ b/lib/dispatcher/get-licence-path.js
@@ -25,7 +25,6 @@ module.exports = task => {
 
     case 'pil':
       const profileId = get(task, 'data.subject');
-      const pilId = get(task, 'data.id');
-      return `establishments/${establishmentId}/people/${profileId}/pil/${pilId}`;
+      return `establishments/${establishmentId}/people/${profileId}/pil`;
   }
 };


### PR DESCRIPTION
The id parameter no longer forms part of the url