### PR TITLE
Fix links to PILs in associated establishment notifications

### DIFF
--- a/lib/dispatcher/content.js
+++ b/lib/dispatcher/content.js
@@ -79,6 +79,10 @@ module.exports = {
     'task-change': 'Status change',
     'task-outgoing': 'Status change',
     'licence-granted': 'Licence granted',
-    'licence-amended': 'Licence amended'
+    'licence-amended': 'Licence amended',
+    'associated-pil-amended': 'Licence amended',
+    'associated-pil-granted': 'Licence granted',
+    'associated-pil-revoked': 'Licence revoked',
+    'associated-pil-transferred': 'Licence transferred'
   }
 };

--- a/lib/dispatcher/get-licence-path.js
+++ b/lib/dispatcher/get-licence-path.js
@@ -1,8 +1,8 @@
 const { get } = require('lodash');
 
-module.exports = task => {
+module.exports = (task, notification = {}) => {
   const model = get(task, 'data.model');
-  const establishmentId = get(task, 'data.establishmentId');
+  const establishmentId = notification.establishmentId || get(task, 'data.establishmentId');
   let projectId;
 
   switch (model) {

--- a/lib/dispatcher/index.js
+++ b/lib/dispatcher/index.js
@@ -19,7 +19,6 @@ const oldTemplateMap = {
 module.exports = ({ schema, emailer, logger, publicUrl }) => async ({ task, notifications }) => {
   const licenceType = getLicenceType(task);
   const taskType = getTaskType(task);
-  const licencePath = getLicencePath(task);
   const model = await getModel({ schema, licenceType, task, logger });
 
   return Promise.all(Array.from(notifications).map(([id, notification]) => {
@@ -30,6 +29,7 @@ module.exports = ({ schema, emailer, logger, publicUrl }) => async ({ task, noti
     const templateName = oldTemplateMap[notification.emailTemplate] || notification.emailTemplate;
     const subject = notification.subject || `${content.subject[templateName]}: ${content.type[licenceType][taskType]}`;
     const recipientName = `${recipient.firstName} ${recipient.lastName}`;
+    const licencePath = getLicencePath(task, notification);
 
     const templateVars = {
       licenceType: get(content, `licenceType[${licenceType}]`),

--- a/lib/recipients/pil.js
+++ b/lib/recipients/pil.js
@@ -21,31 +21,42 @@ module.exports = ({ schema, logger, task }) => {
   const getAdmins = establishmentId => Profile.query()
     .scopeToEstablishment('establishments.id', establishmentId, 'admin');
 
-  const getNonOwningAdmins = applicantId => Profile.query().findById(applicantId).eager('[establishments]')
-    .then(applicant => applicant.establishments.filter(e => e.id !== establishmentId).map(e => e.id))
-    .then(nonOwningEstablishmentIds => {
-      if (nonOwningEstablishmentIds.length < 1) {
-        return [];
-      }
+  const getNonOwningAdmins = applicant => {
+    return Promise.resolve()
+      .then(() => applicant.establishments.filter(e => e.id !== establishmentId).map(e => e.id))
+      .then(nonOwningEstablishmentIds => {
+        if (nonOwningEstablishmentIds.length < 1) {
+          return [];
+        }
 
-      return Profile.query()
-        .joinRelation('establishments')
-        .whereIn('establishmentId', nonOwningEstablishmentIds)
-        .andWhere({ role: 'admin' })
-        .whereNot('profiles.id', applicantId);
+        return Profile.query()
+          .withGraphFetched('[establishments]')
+          .joinRelation('establishments')
+          .whereIn('establishmentId', nonOwningEstablishmentIds)
+          .andWhere({ role: 'admin' })
+          .whereNot('profiles.id', applicantId);
+      });
+  };
+
+  const getCommonEstablishment = (admin, applicant) => {
+    return admin.establishments.find(establishment => {
+      return establishment.role === 'admin' && applicant.establishments.some(e => e.id === establishment.id);
     });
+  };
 
-  const getNtcos = establishmentId => Profile.query()
-    .scopeToEstablishment('establishments.id', establishmentId)
-    .joinRelation('roles')
-    .where('roles.type', 'ntco');
+  const getNtcos = establishmentId => {
+    return Profile.query()
+      .scopeToEstablishment('establishments.id', establishmentId)
+      .joinRelation('roles')
+      .where('roles.type', 'ntco');
+  };
 
   if (!allowedActions.includes(action)) {
     logger.verbose(`ignoring task: pil ${action}`);
     return Promise.resolve(new Map());
   }
 
-  return Profile.query().findById(applicantId)
+  return Profile.query().findById(applicantId).withGraphFetched('[establishments]')
     .then(applicant => {
       logger.debug(`applicant is ${applicant.firstName} ${applicant.lastName}`);
 
@@ -120,25 +131,26 @@ module.exports = ({ schema, logger, task }) => {
         .then(() => {
           if (taskHelper.isResolved(task)) {
             // notify any other associated establishment admins that a PIL has been granted / amended / transferred / revoked
-            return getNonOwningAdmins(applicantId)
+            return getNonOwningAdmins(applicant)
               .then(otherAdmins => {
                 otherAdmins.map(profile => {
+                  const establishment = getCommonEstablishment(profile, applicant);
                   switch (action) {
                     case 'grant':
                       logger.verbose('PIL is granted, notifying non-owning-establishment admins');
-                      notifications.set(profile.id, { emailTemplate: 'associated-pil-granted', applicant, recipient: profile });
+                      notifications.set(profile.id, { emailTemplate: 'associated-pil-granted', applicant, recipient: profile, establishmentId: establishment.id });
                       break;
                     case 'transfer':
                       logger.verbose('PIL is transferred, notifying non-owning-establishment admins');
-                      notifications.set(profile.id, { emailTemplate: 'associated-pil-transferred', applicant, recipient: profile });
+                      notifications.set(profile.id, { emailTemplate: 'associated-pil-transferred', applicant, recipient: profile, establishmentId: establishment.id });
                       break;
                     case 'revoke':
                       logger.verbose('PIL is revoked, notifying non-owning-establishment admins');
-                      notifications.set(profile.id, { emailTemplate: 'associated-pil-revoked', applicant, recipient: profile });
+                      notifications.set(profile.id, { emailTemplate: 'associated-pil-revoked', applicant, recipient: profile, establishmentId: establishment.id });
                       break;
                     default:
                       logger.verbose('PIL is updated, notifying non-owning-establishment admins');
-                      notifications.set(profile.id, { emailTemplate: 'associated-pil-amended', applicant, recipient: profile });
+                      notifications.set(profile.id, { emailTemplate: 'associated-pil-amended', applicant, recipient: profile, establishmentId: establishment.id });
                   }
                 });
               });

--- a/test/specs/models/pil/application.js
+++ b/test/specs/models/pil/application.js
@@ -210,7 +210,8 @@ describe('PIL applications', () => {
       return this.recipientBuilder.getNotifications(pilApplicationGranted)
         .then(recipients => {
           assert(recipients.has(marvellAdmin), 'marvellAdmin is in the recipients list');
-          assert(recipients.get(marvellAdmin).emailTemplate === 'associated-pil-granted', 'email type is task-closed');
+          assert.equal(recipients.get(marvellAdmin).emailTemplate, 'associated-pil-granted', 'email type is task-closed');
+          assert.equal(recipients.get(marvellAdmin).establishmentId, 8202, 'establishmentId should be set to Marvell');
         });
     });
 


### PR DESCRIPTION
When an admin receives a notification that a PIL held elsewhere by someone at their establishment has been amended then they get an email with a link to the PIL in it. However, that link has the establishment id of the PIL holding establishment in it so 404s when they access it.

Find a common establishment id for the admin and the PIL holder and use that to render PIL links.

Additionally fix some missing content that is resulting in emails with `undefined` in the subject.