### PR TITLE
Bugfix - notify new ppl holder when licence holder updated

### DIFF
--- a/lib/utils/task.js
+++ b/lib/utils/task.js
@@ -76,8 +76,10 @@ module.exports = {
         return true;
 
       case 'pil':
-      case 'project':
         return ['grant', 'transfer'].includes(action);
+
+      case 'project':
+        return ['grant', 'transfer', 'update'].includes(action);
 
       case 'establishment':
         return action === 'grant';


### PR DESCRIPTION
The code that notifies the new licence holder was unreachable as update was not included in the list of allowed grant tasks