### PR TITLE
Narrow window for sending project expiry notifications to one week

### DIFF
--- a/tasks/project-expiry-notice.js
+++ b/tasks/project-expiry-notice.js
@@ -1,9 +1,9 @@
 const moment = require('moment');
 const Emailer = require('../lib/emailer');
 
-function expiryNotice(emailer, Project, upper, lower, action) {
+function expiryNotice(emailer, Project, upper, action) {
   const ub = moment().add(upper, 'months').toISOString();
-  const lb = moment().add(lower, 'months').toISOString();
+  const lb = moment().add(upper, 'months').subtract(1, 'week').toISOString();
 
   return Promise.resolve()
     .then(() => {
@@ -40,8 +40,8 @@ module.exports = ({ schema, logger, publicUrl }) => {
   const emailer = Emailer({ schema, logger, publicUrl });
 
   return Promise.resolve()
-    .then(() => expiryNotice(emailer, Project, 12, 6, 'project-expiring-12'))
-    .then(() => expiryNotice(emailer, Project, 6, 3, 'project-expiring-6'))
-    .then(() => expiryNotice(emailer, Project, 3, 0, 'project-expiring-3'))
-    .then(() => expiryNotice(emailer, Project, 0, -1, 'project-expired'));
+    .then(() => expiryNotice(emailer, Project, 12, 'project-expiring-12'))
+    .then(() => expiryNotice(emailer, Project, 6, 'project-expiring-6'))
+    .then(() => expiryNotice(emailer, Project, 3, 'project-expiring-3'))
+    .then(() => expiryNotice(emailer, Project, 0, 'project-expired'));
 };

--- a/test/specs/tasks/project-expiry-notice.js
+++ b/test/specs/tasks/project-expiry-notice.js
@@ -28,7 +28,7 @@ describe('Project expiry', () => {
   it('adds 12 month notification for a project due to expire in 12 months', () => {
     const project = {
       licenceHolderId: basic,
-      expiryDate: moment().add(1, 'year').toISOString(),
+      expiryDate: moment().add(1, 'year').subtract(1, 'day').toISOString(),
       status: 'active',
       establishmentId: 8201,
       licenceNumber: 'XYZ12345'
@@ -57,7 +57,7 @@ describe('Project expiry', () => {
   it('adds 6 month notification for a project due to expire in 6 months', () => {
     const project = {
       licenceHolderId: basic,
-      expiryDate: moment().add(6, 'months').toISOString(),
+      expiryDate: moment().add(6, 'months').subtract(1, 'day').toISOString(),
       status: 'active',
       establishmentId: 8201,
       licenceNumber: 'XYZ12345'
@@ -86,7 +86,7 @@ describe('Project expiry', () => {
   it('adds 3 month notification for a project due to expire in 3 months', () => {
     const project = {
       licenceHolderId: basic,
-      expiryDate: moment().add(3, 'months').toISOString(),
+      expiryDate: moment().add(3, 'months').subtract(1, 'day').toISOString(),
       status: 'active',
       establishmentId: 8201,
       licenceNumber: 'XYZ12345'
@@ -112,10 +112,10 @@ describe('Project expiry', () => {
       });
   });
 
-  it('adds an expiry notification for a project that has expired in the last month', () => {
+  it('adds an expiry notification for a project that has expired in the last week', () => {
     const project = {
       licenceHolderId: basic,
-      expiryDate: moment().toISOString(),
+      expiryDate: moment().subtract(1, 'day').toISOString(),
       status: 'expired',
       establishmentId: 8201,
       licenceNumber: 'XYZ12345'
@@ -141,10 +141,10 @@ describe('Project expiry', () => {
       });
   });
 
-  it('doesn\'t add an expiry notification for a project that has expired over a month ago', () => {
+  it('doesn\'t add an expiry notification for a project that has expired over a week ago', () => {
     const project = {
       licenceHolderId: basic,
-      expiryDate: moment().subtract(5, 'weeks').toISOString(),
+      expiryDate: moment().subtract(9, 'days').toISOString(),
       status: 'expired',
       establishmentId: 8201,
       licenceNumber: 'XYZ12345'


### PR DESCRIPTION
This means that when the feature first launches only projects which would have "recently" been notifed of an expiry will be sent an email, not all projects due to expire within the next year.

Define "recently" as within one week.

This should have no real effect on the normal running of the service post launch as it is unlikely that notifications would fail repeatedly for an entire week.