### PR TITLE
Remove ROPs call to action from project expiry emails

### DIFF
--- a/lib/dispatcher/templates/project-expired.js
+++ b/lib/dispatcher/templates/project-expired.js
@@ -9,8 +9,8 @@ All work authorised under this licence must stop immediately. You are reminded t
 If you are the licence holder you must now:
 
 1. Attend to animals that are suffering - or are likely to suffer - as a result of regulated procedures by either quickly and humanely killing them in line with section 15 of the Animals (Scientific Procedures) Act 1986, or transferring them to a new project licence.
-1. [Submit a return of procedures]({{licenceUrl}}#reporting) by {{ropsDate}}.
-{{#raDate}}1. [Submit a retrospective assessment]({{licenceUrl}}#reporting) by {{raDate}}.{{/raDate}}
+1. Submit a return of procedures by {{ropsDate}}.
+{{#raDate}}1. [Submit a retrospective assessment]({{licenceUrl}}) by {{raDate}}.{{/raDate}}
 1. Submit a list of any publications your work has been published in by {{publicationsDate}}. This should be emailed to aspa.london@homeoffice.gov.uk.
 
 These requirements are conditions of your licence. Failure to fulfil any of them constitutes a breach of your licence terms.

--- a/lib/dispatcher/templates/project-expiring.js
+++ b/lib/dispatcher/templates/project-expiring.js
@@ -9,8 +9,8 @@ From {{expiryDate}} all work authorised under this licence must stop. You are re
 If you are the licence holder, on expiry of this licence you must:
 
 1. Attend to animals that are suffering - or are likely to suffer - as a result of regulated procedures by either quickly and humanely killing them in line with section 15 of the Animals (Scientific Procedures) Act 1986, or transferring them to a new project licence.
-1. [Submit a return of procedures]({{licenceUrl}}#reporting) by {{ropsDate}}.
-{{#raDate}}1. [Submit a retrospective assessment]({{licenceUrl}}#reporting) by {{raDate}}.{{/raDate}}
+1. Submit a return of procedures by {{ropsDate}}.
+{{#raDate}}1. [Submit a retrospective assessment]({{licenceUrl}}) by {{raDate}}.{{/raDate}}
 1. Submit a list of any publications your work has been published in by {{publicationsDate}}. This should be emailed to aspa.london@homeoffice.gov.uk.
 
 These requirements are conditions of your licence. Failure to fulfil any of them constitutes a breach of your licence terms.


### PR DESCRIPTION
Submission of ROPs is not generally available so we shouldn't be prmpting people to do a thing that they can't do.