### PR TITLE
Don't notify unaffiliated collaborators

### DIFF
--- a/lib/recipients/project.js
+++ b/lib/recipients/project.js
@@ -33,7 +33,7 @@ module.exports = async ({ schema, logger, task }) => {
     return Promise.resolve(new Map());
   }
 
-  const project = await Project.query().findById(projectId).withGraphFetched('[licenceHolder, collaborators.emailPreferences]');
+  const project = await Project.query().findById(projectId).withGraphFetched('[additionalEstablishments, licenceHolder, collaborators.[emailPreferences,establishments]]');
 
   // if the task is an unresolved transfer, we want to notify the
   // current establishment admins, not the incoming ones.
@@ -67,6 +67,12 @@ module.exports = async ({ schema, logger, task }) => {
       return subscribed({ establishmentId: admin.aaEstablishmentId, licenceType: 'ppl', profile: admin });
     }));
 
+  const hasProjectAffiliation = collaborator => {
+    // check that a collaborator is affiliated to at least one of the associated establishments
+    return collaborator.establishments
+      .some(e => e.id === project.establishmentId || project.additionalEstablishments.some(ae => ae.id === e.id));
+  };
+
   const notifyUser = (recipient, params) => {
     logger.verbose(`${params.logMsg}, notifying licence holder / applicant`);
     notifications.set(recipient.id, { ...params, recipient });
@@ -75,6 +81,7 @@ module.exports = async ({ schema, logger, task }) => {
   const notifyCollaborators = params => {
     logger.verbose(`${params.logMsg}, notifying project collaborators`);
     project.collaborators
+      .filter(collaborator => hasProjectAffiliation(collaborator))
       .filter(collaborator => subscribedToCollaborations(collaborator))
       .forEach(collaborator => notifications.set(collaborator.id, { ...params, recipient: collaborator }));
   };

--- a/test/data/default.js
+++ b/test/data/default.js
@@ -13,6 +13,7 @@ const {
   research101Admin2,
   research101AdminUnsubscribed,
   collaborator,
+  collaboratorUnaffiliated,
   collaboratorUnsubscribed,
   trainingOwner,
   trainingNtco,
@@ -299,6 +300,15 @@ module.exports = models => {
               role: 'basic'
             }
           ]
+        },
+        {
+          id: collaboratorUnaffiliated,
+          title: 'Ms',
+          firstName: 'ExCollab',
+          lastName: 'Orator',
+          dob: '1970-10-27',
+          email: 'excollab.orator@example.com',
+          establishments: []
         },
         {
           id: collaboratorUnsubscribed,

--- a/test/helpers/users.js
+++ b/test/helpers/users.js
@@ -11,6 +11,7 @@ module.exports = {
   research101Admin2: 'e7b205cf-1acf-4eb3-bcde-ab63c21d0551',
   research101AdminUnsubscribed: '7371e6c5-1836-40bd-98c2-ce05193539ed',
   collaborator: 'c1bf9c86-fed7-4ea7-949c-e99ffeed717b',
+  collaboratorUnaffiliated: 'fb59edef-de93-4cdc-a15f-74f9003dcc51',
   collaboratorUnsubscribed: '5902a1d5-1635-4ccd-b9c8-db4d20aac847',
   trainingLicenceHolder: '0c130d97-35f1-455f-b7db-a16ca0a7a2ea',
   trainingOwner: '084457d6-0f38-43dd-b133-70858ff4b3de',

--- a/test/specs/models/project/application.js
+++ b/test/specs/models/project/application.js
@@ -2,7 +2,15 @@ const assert = require('assert');
 const dbHelper = require('../../../helpers/db');
 const logger = require('../../../helpers/logger');
 const Recipients = require('../../../../lib/recipients');
-const { basic, croydonAdmin1, croydonAdmin2, croydonAdminUnsubscribed, collaborator, collaboratorUnsubscribed } = require('../../../helpers/users');
+const {
+  basic,
+  croydonAdmin1,
+  croydonAdmin2,
+  croydonAdminUnsubscribed,
+  collaborator,
+  collaboratorUnaffiliated,
+  collaboratorUnsubscribed
+} = require('../../../helpers/users');
 
 const {
   projectApplicationSubmitted,
@@ -164,6 +172,13 @@ describe('Project applications', () => {
           assert(recipients.get(collaborator).emailTemplate === 'licence-granted', 'email type is licence-granted');
           assert(recipients.get(collaborator).applicant.id === basic, 'basic user is the applicant');
           assert(!recipients.has(collaboratorUnsubscribed), 'collaboratorUnsubscribed is not in the recipients list');
+        });
+    });
+
+    it('does not notify collaborators if they have been removed from an establishment', () => {
+      return this.recipientBuilder.getNotifications(projectApplicationGranted)
+        .then(recipients => {
+          assert(!recipients.has(collaboratorUnaffiliated), 'collaboratorUnaffiliated should not be in the recipients list');
         });
     });
 


### PR DESCRIPTION
If a user was a collaborator on a project, but their affiliation with the PPL holding establishment (or AA establishment) was removed then they should not longer receive notifications relating to the project.