### PR TITLE
Fix: suspend/reinstate emails had broken subject text

### DIFF
--- a/lib/dispatcher/content.js
+++ b/lib/dispatcher/content.js
@@ -5,7 +5,9 @@ module.exports = {
       amendment: 'PIL amendment',
       revocation: 'PIL revocation',
       transfer: 'PIL transfer',
-      review: '5 year PIL review'
+      review: '5 year PIL review',
+      suspension: 'PIL suspension',
+      reinstatement: 'PIL reinstatement'
     },
     trainingPil: {
       application: 'Category E PIL application',
@@ -17,12 +19,16 @@ module.exports = {
       amendment: 'PPL amendment',
       revocation: 'PPL revocation',
       transfer: 'PPL transfer',
-      ra: 'retrospective assessment'
+      ra: 'retrospective assessment',
+      suspension: 'PPL suspension',
+      reinstatement: 'PPL reinstatement'
     },
     pel: {
       application: 'PEL application',
       amendment: 'PEL amendment',
-      revocation: 'PEL revocation'
+      revocation: 'PEL revocation',
+      suspension: 'PEL suspension',
+      reinstatement: 'PEL reinstatement'
     },
     profile: {
       amendment: 'Profile update'
@@ -93,6 +99,8 @@ module.exports = {
     'task-outgoing': 'Status change {{licenceNumber}}',
     'licence-granted': 'Licence granted {{licenceNumber}}',
     'licence-amended': 'Licence amended {{licenceNumber}}',
+    'licence-suspended': `{{taskType}} {{licenceNumber}}`,
+    'licence-reinstated': `{{taskType}} {{licenceNumber}}`,
     'associated-pil-amended': 'Licence amended {{licenceNumber}}',
     'associated-pil-granted': 'Licence granted {{licenceNumber}}',
     'associated-pil-revoked': 'Licence revoked {{licenceNumber}}',

--- a/lib/dispatcher/get-task-type.js
+++ b/lib/dispatcher/get-task-type.js
@@ -12,6 +12,14 @@ module.exports = task => {
     return 'revocation';
   }
 
+  if (action === 'suspend') {
+    return 'suspension';
+  }
+
+  if (action === 'reinstate') {
+    return 'reinstatement';
+  }
+
   if (['transfer', 'review'].includes(action)) {
     return action;
   }

--- a/lib/dispatcher/templates/licence-reinstated.js
+++ b/lib/dispatcher/templates/licence-reinstated.js
@@ -7,9 +7,11 @@ Reinstatement date: {{reinstatedDate}}
 
 All work authorised under this licence may continue.
 
+[You can view the reinstatement here (log in required)]({{{taskUrl}}}).
+
 Should you have any queries, please email our licensing team at asrulicensing@homeoffice.gov.uk.`;
 
 module.exports = {
-  requires: ['modelType', 'licenceNumber', 'suspendedDate', 'reinstatedDate'],
+  requires: ['modelType', 'licenceNumber', 'suspendedDate', 'reinstatedDate', 'taskUrl'],
   value
 };

--- a/lib/dispatcher/templates/licence-suspended.js
+++ b/lib/dispatcher/templates/licence-suspended.js
@@ -7,9 +7,11 @@ Suspension date: {{suspendedDate}}
 All work authorised under this licence must stop immediately. You are reminded that it is illegal to perform regulated
 procedures without a licence.
 
+[You can view the suspension here (log in required)]({{{taskUrl}}}).
+
 Should you have any queries, please email our licensing team at asrulicensing@homeoffice.gov.uk.`;
 
 module.exports = {
-  requires: ['modelType', 'licenceNumber', 'suspendedDate'],
+  requires: ['modelType', 'licenceNumber', 'suspendedDate', 'taskUrl'],
   value
 };

--- a/lib/recipients/establishment.js
+++ b/lib/recipients/establishment.js
@@ -151,7 +151,6 @@ module.exports = async ({ schema, logger, task }) => {
   }
 
   if (taskHelper.isSuspension(task)) {
-    console.log(task);
     const suspensionParams = {
       ...params,
       modelType: 'establishment',
@@ -170,7 +169,6 @@ module.exports = async ({ schema, logger, task }) => {
   }
 
   if (taskHelper.isReinstatement(task)) {
-    console.log(task);
     const reinstatementParams = {
       ...params,
       modelType: 'establishment',

--- a/lib/recipients/establishment.js
+++ b/lib/recipients/establishment.js
@@ -151,6 +151,7 @@ module.exports = async ({ schema, logger, task }) => {
   }
 
   if (taskHelper.isSuspension(task)) {
+    console.log(task);
     const suspensionParams = {
       ...params,
       modelType: 'establishment',
@@ -169,6 +170,7 @@ module.exports = async ({ schema, logger, task }) => {
   }
 
   if (taskHelper.isReinstatement(task)) {
+    console.log(task);
     const reinstatementParams = {
       ...params,
       modelType: 'establishment',

--- a/lib/recipients/establishment.js
+++ b/lib/recipients/establishment.js
@@ -156,7 +156,8 @@ module.exports = async ({ schema, logger, task }) => {
       modelType: 'establishment',
       emailTemplate: 'licence-suspended',
       logMsg: 'Establishment suspended',
-      suspendedDate: establishment.suspendedDate && moment(establishment.suspendedDate).format(dateFormat)
+      suspendedDate: establishment.suspendedDate && moment(establishment.suspendedDate).format(dateFormat),
+      addTaskTypeToSubject: false
     };
 
     notifyPelh(suspensionParams);
@@ -174,7 +175,8 @@ module.exports = async ({ schema, logger, task }) => {
       emailTemplate: 'licence-reinstated',
       logMsg: 'Establishment reinstated',
       suspendedDate: establishment.suspendedDate && moment(establishment.suspendedDate).format(dateFormat),
-      reinstatedDate: moment().format(dateFormat)
+      reinstatedDate: moment().format(dateFormat),
+      addTaskTypeToSubject: false
     };
 
     notifyPelh(reinstatementParams);

--- a/lib/recipients/pil.js
+++ b/lib/recipients/pil.js
@@ -166,7 +166,8 @@ module.exports = async ({ schema, logger, task, publicUrl }) => {
       modelType: 'personal',
       emailTemplate: 'licence-suspended',
       logMsg: 'PIL suspended',
-      suspendedDate: pil && pil.suspendedDate && moment(pil.suspendedDate).format(dateFormat)
+      suspendedDate: pil && pil.suspendedDate && moment(pil.suspendedDate).format(dateFormat),
+      addTaskTypeToSubject: false
     };
 
     notifyUser(suspensionParams);
@@ -183,7 +184,8 @@ module.exports = async ({ schema, logger, task, publicUrl }) => {
       emailTemplate: 'licence-reinstated',
       logMsg: 'PIL reinstated',
       suspendedDate: pil && pil.suspendedDate && moment(pil.suspendedDate).format(dateFormat),
-      reinstatedDate: moment().format(dateFormat)
+      reinstatedDate: moment().format(dateFormat),
+      addTaskTypeToSubject: false
     };
 
     notifyUser(reinstatementParams);

--- a/lib/recipients/project.js
+++ b/lib/recipients/project.js
@@ -149,7 +149,8 @@ module.exports = async ({ schema, logger, task, publicUrl }) => {
       modelType: 'project',
       emailTemplate: 'licence-suspended',
       logMsg: 'Project suspended',
-      suspendedDate: project && project.suspendedDate && moment(project.suspendedDate).format(dateFormat)
+      suspendedDate: project && project.suspendedDate && moment(project.suspendedDate).format(dateFormat),
+      addTaskTypeToSubject: false
     };
 
     notifyUser(project.licenceHolder, suspensionParams);
@@ -165,7 +166,9 @@ module.exports = async ({ schema, logger, task, publicUrl }) => {
       modelType: 'project',
       emailTemplate: 'licence-reinstated',
       logMsg: 'Project reinstated',
-      suspendedDate: project && project.suspendedDate && moment(project.suspendedDate).format(dateFormat)
+      suspendedDate: project && project.suspendedDate && moment(project.suspendedDate).format(dateFormat),
+      reinstatedDate: moment().format(dateFormat),
+      addTaskTypeToSubject: false
     };
 
     notifyUser(project.licenceHolder, reinstatementParams);

--- a/lib/utils/task.js
+++ b/lib/utils/task.js
@@ -141,7 +141,7 @@ const taskHelper = {
   },
 
   allowedUpdate: task => {
-    return isDeadlineExtension(task) || isSuspension(task) || isReinstatement(task);
+    return isDeadlineExtension(task);
   },
 
   isIntentionToRefuseNotice: task => {

--- a/test/data/tasks/establishment/pel-reinstated.js
+++ b/test/data/tasks/establishment/pel-reinstated.js
@@ -38,9 +38,9 @@ module.exports = {
       changedBy: 'a942ffc7-e7ca-4d76-a001-0b5048a057d1'
     }
   },
-  event: 'update',
+  event: 'status:new:resolved',
+  status: 'resolved',
   comment: 'Failures resolved.',
-  status: 'new',
   data: {
     id: 8201,
     data: {},

--- a/test/data/tasks/establishment/pel-suspended.js
+++ b/test/data/tasks/establishment/pel-suspended.js
@@ -38,9 +38,9 @@ module.exports = {
       changedBy: 'a942ffc7-e7ca-4d76-a001-0b5048a057d1'
     }
   },
-  event: 'update',
+  event: 'status:new:resolved',
+  status: 'resolved',
   comment: 'Failures at the top.',
-  status: 'new',
   data: {
     id: 8201,
     data: {},

--- a/test/data/tasks/pil/pil-reinstated.js
+++ b/test/data/tasks/pil/pil-reinstated.js
@@ -47,9 +47,9 @@ module.exports = {
       changedBy: 'a942ffc7-e7ca-4d76-a001-0b5048a057d1'
     }
   },
-  event: 'update',
+  event: 'status:new:resolved',
+  status: 'resolved',
   comment: 'Now complying.',
-  status: 'new',
   data: {
     id: pilId,
     data: {

--- a/test/data/tasks/pil/pil-suspended.js
+++ b/test/data/tasks/pil/pil-suspended.js
@@ -47,9 +47,9 @@ module.exports = {
       changedBy: 'a942ffc7-e7ca-4d76-a001-0b5048a057d1'
     }
   },
-  event: 'update',
+  event: 'status:new:resolved',
+  status: 'resolved',
   comment: 'Failure to comply.',
-  status: 'new',
   data: {
     id: pilId,
     data: {

--- a/test/data/tasks/project/project-reinstated.js
+++ b/test/data/tasks/project/project-reinstated.js
@@ -45,9 +45,9 @@ module.exports = {
       changedBy: 'a942ffc7-e7ca-4d76-a001-0b5048a057d1'
     }
   },
-  event: 'update',
+  event: 'status:new:resolved',
+  status: 'resolved',
   comment: 'Compliance met',
-  status: 'new',
   data: {
     id: projectId,
     data: { establishmentId: 8201 },

--- a/test/data/tasks/project/project-suspended.js
+++ b/test/data/tasks/project/project-suspended.js
@@ -45,9 +45,9 @@ module.exports = {
       changedBy: 'a942ffc7-e7ca-4d76-a001-0b5048a057d1'
     }
   },
-  event: 'update',
+  event: 'status:new:resolved',
+  status: 'resolved',
   comment: 'Compliance issues.',
-  status: 'new',
   data: {
     id: projectId,
     data: { establishmentId: 8201 },


### PR DESCRIPTION
Also fixed: suspend date was actually missing from the content due to the notification getting sent before the suspendDate column was set on the licence.